### PR TITLE
MNT: Use noarch python {{ python_min }} variable

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_min:
+- '3.9'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "scikit-hep-testdata" %}
 {% set version = "0.5.0" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -10,18 +11,18 @@ source:
   sha256: 50b7d14d558cd14e8dad4021ae02c3068a29a613be39fbc046fd79c15af56819
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: 'SETUPTOOLS_SCM_PRETEND_VERSION={{ version }} {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+  script: SETUPTOOLS_SCM_PRETEND_VERSION={{ version }} {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python {{ python_min }}
     - setuptools
     - setuptools_scm
   run:
-    - python >=3.8
+    - python >={{ python_min }}
     - pyyaml
     - importlib_resources
     - requests
@@ -30,6 +31,7 @@ test:
   source_files:
     - tests
   requires:
+    - python {{ python_min }}
     - pytest
     - pip
   imports:


### PR DESCRIPTION
* Use 'python {{ python_min }}' syntax for the python requirements for noarch python recipes.
   - c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python
* Use a Jinja2 set statement for python_min to keep all the build metadata contained in the recipe/meta.yaml and override the global python_min with scikit-hep-testdata's python_min of 3.9.
* Remove --no-deps --no-build-isolation 'pip install' options in recipes as the build tool (e.g. conda-build, rattler-build) will enforce all required 'pip install' options itself at build time.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
